### PR TITLE
Skip gpg install on macOS wheel builds

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -30,9 +30,6 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - name: Install native dependencies (MacOS)
-        run: brew install swig gpgme
-        if: "matrix.os == 'macos-latest'"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -44,7 +41,7 @@ jobs:
           cp .github/gpg-error-config "$HOME/.local/bin/gpg-error-config"
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           pip install -U gpg
-        if: "matrix.os != 'windows-latest'"
+        if: "matrix.os == 'ubuntu-latest'"
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
         if: "matrix.os == 'ubuntu-latest'"


### PR DESCRIPTION
The gpg pip package fails to build on macOS (gpgme.h not found) and is only used in CI, not by the wheel itself. Build it only on Ubuntu and drop the now-unused brew gpgme/swig step.